### PR TITLE
Fix typo in "Publish" step in GitHub Actions

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -31,6 +31,6 @@ jobs:
       working-directory: ./src
       if: ${{ github.ref == 'refs/heads/main' }}
     - name: Publish
-      run: dotnet nuget publish "*.nupkg" --api-key ${{secrets.NUGET_API_KEY}} --source https://api.nuget.org/v3/index.json
+      run: dotnet nuget push "*.nupkg" --api-key ${{secrets.NUGET_API_KEY}} --source https://api.nuget.org/v3/index.json
       working-directory: ./src
       if: ${{ github.ref == 'refs/heads/main' }}


### PR DESCRIPTION
I tested with `dotnet nuget push` locally and then put `dotnet nuget publish` in the script - this PR fixes that mistake.